### PR TITLE
Display lowest attribute price on shop page

### DIFF
--- a/models/product_template.py
+++ b/models/product_template.py
@@ -6,31 +6,27 @@ from odoo import models, fields, api
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    @api.model
     def _get_cheapest_active_variant_price(self):
         """
-        Calculate the cheapest price among all active (non-archived) variants.
-        Returns the base price if no active variants exist.
+        Return the minimal website price among active (non-archived) variants
+        according to the current pricelist context. Falls back to the template
+        list price when there are no active variants or no computed prices.
         """
+        self.ensure_one()
+
         if not self.product_variant_ids:
             return self.list_price
 
-        # Get all active variants (not archived)
-        active_variants = self.product_variant_ids.filtered(lambda v: v.active)
-
+        active_variants = self.product_variant_ids.filtered(lambda variant: variant.active)
         if not active_variants:
             return self.list_price
 
-        # Calculate the price for each active variant
-        cheapest_price = float('inf')
-
+        cheapest_price = None
         for variant in active_variants:
-            # Get the combination info for this variant
             combination_info = self._get_combination_info(variant.product_template_attribute_value_ids.ids)
-            variant_price = combination_info.get('price', 0)
+            variant_price = combination_info.get('price') or 0.0
 
-            if variant_price < cheapest_price:
+            if cheapest_price is None or variant_price < cheapest_price:
                 cheapest_price = variant_price
 
-        # Return the cheapest price, or base price if no valid prices found
-        return cheapest_price if cheapest_price != float('inf') else self.list_price
+        return cheapest_price if cheapest_price is not None else self.list_price

--- a/models/product_template.py
+++ b/models/product_template.py
@@ -24,7 +24,11 @@ class ProductTemplate(models.Model):
         cheapest_price = None
         for variant in active_variants:
             combination_info = self._get_combination_info(variant.product_template_attribute_value_ids.ids)
-            variant_price = combination_info.get('price') or 0.0
+            variant_price = combination_info.get('price', None)
+
+            # Treat missing/nullable prices as positive infinity to avoid selecting them as cheapest
+            if variant_price is None:
+                continue
 
             if cheapest_price is None or variant_price < cheapest_price:
                 cheapest_price = variant_price

--- a/models/product_template.py
+++ b/models/product_template.py
@@ -24,13 +24,14 @@ class ProductTemplate(models.Model):
         cheapest_price = None
         for variant in active_variants:
             combination_info = self._get_combination_info(variant.product_template_attribute_value_ids.ids)
-            variant_price = combination_info.get('price', None)
+            variant_price = combination_info.get('price', float('inf'))
 
-            # Treat missing/nullable prices as positive infinity to avoid selecting them as cheapest
             if variant_price is None:
-                continue
+                variant_price = float('inf')
 
             if cheapest_price is None or variant_price < cheapest_price:
                 cheapest_price = variant_price
 
-        return cheapest_price if cheapest_price is not None else self.list_price
+        if cheapest_price is None or cheapest_price == float('inf'):
+            return self.list_price
+        return cheapest_price

--- a/views/website_sale_templates.xml
+++ b/views/website_sale_templates.xml
@@ -23,8 +23,13 @@
     <!-- Override products_item template to show cheapest active variant price -->
     <template id="products_item_cheapest_price" name="Products Item Cheapest Price" inherit_id="website_sale.products_item">
         <xpath expr="//div[@class='product_price']//span[@t-if='template_price_vals[\'price_reduce\'] or not website.prevent_zero_price_sale']" position="replace">
-            <span t-out="product._get_cheapest_active_variant_price()"
-                t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+            <t t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
+                <span t-out="product._get_cheapest_active_variant_price()"
+                    t-options='{
+                        "widget": "monetary",
+                        "display_currency": (website.pricelist_id or product.env.company).currency_id
+                    }'/>
+            </t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Display the lowest active variant price for products on shop pages to ensure the correct minimal price is shown when product variants have different prices.

---
<a href="https://cursor.com/background-agent?bcId=bc-d94f6f20-e142-44c0-b3df-e25ce0dea360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d94f6f20-e142-44c0-b3df-e25ce0dea360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

